### PR TITLE
2.1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = krdict.py
-version = 2.1.2
+version = 2.1.3
 author = Omar M.
 author_email = omarkmu@gmail.com
 description = A module that helps with querying the Korean Learners' Dictionary API.
@@ -19,6 +19,7 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
+include_package_data = True
 package_dir =
     = src
 packages =


### PR DESCRIPTION
Added `include_package_data = True` to `setup.cfg`. This should make the fix in 2.11 function as intended for new installations of the package.